### PR TITLE
:bug: sort categories by name (#1)

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -56,7 +56,8 @@ summary {
 	{%- if page.permalink == "/notes/" -%}
 		<h1 style='text-align:center'> MENU </h1>
 		{% assign mydocs = site.notes | group_by_exp: 'item', "item.category | downcase"  %}
-		{% for cat in mydocs %}
+		{% assign mydocsSorted = mydocs | sort: "name"  %}
+		{% for cat in mydocsSorted %}
 			{%- if cat.name != 'false' -%} 
 				<details class="second">
 					<summary>{{ cat.name | upcase }}</summary>


### PR DESCRIPTION
Live on my fork, but wanted to contribute it back.
Properly addresses #1

![image](https://user-images.githubusercontent.com/1540737/143230985-47f93a9e-b3a1-42db-a823-eb945a11f3f8.png)
